### PR TITLE
Expose OAuth headers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,0 +1,42 @@
+#+TITLE: Changes
+
+* 0.2.0
+There are some fairly significant *breaking* changes in this release for anyone
+who made direct use of ~signed-request~ and its associated schema.
+
+~signed-request~ has been renamed to ~sign-request~ and has slightly modified
+behaviour. Firstly, you can now omit OAuth headers when calling ~signed-request~
+if you're trying to send an authenticated request.
+
+#+begin_src clojure
+  (require '[oauth.one :as one])
+
+  (def consumer
+    (one/make-consumer {:key "etc"}))
+
+  (one/sign-request
+   consumer
+   {:request-method :get
+    :url "https://api.twitter.com/account/verify_credentials"})
+#+end_src
+
+You can create a header map directly via the new, public ~make-oauth-headers~
+function if you want to associate some state in before creating a signed request
+via ~sign-request~.
+
+#+begin_src clojure
+  (one/sign-request
+   consumer
+   {:request-method :get
+    :oauth-headers
+    (assoc
+     (one/make-oauth-headers consumer)
+     "oauth_extension" "etc")
+    :url "https://api.twitter.com/account/verify_credentials"})
+#+end_src
+
+You may notice, ~:oauth-headers~ used to be called ~:oauth-params~. The tests
+have been updated accordingly, and are a good place to look for up-to-date
+examples of how to use the library.
+
+In addition, the version of Schema being used has been upgraded to 1.1.0.

--- a/README.org
+++ b/README.org
@@ -163,3 +163,28 @@ Again, to actually send the request you can use your favourite HTTP library.
 The response from this last request will contain the actual ~oauth_token~ and
 ~oauth_token_secret~. These you'll likely want to store in your database because
 they're the credentials you'll use to masquerade as your new user.
+** Signing requests
+Once you have your hands on both your application credentials, and a user's
+token you can send requests on behalf of that user. These requests have to be
+cryptographically signed like any other so there's a function provided to make
+this easier in your app.
+
+#+begin_src clojure
+  (one/sign-request
+   consumer
+   {:request-method :get
+    :url "https://api.twitter.com/account/verify_credentials"})
+#+end_src
+
+You can use the hash-map returned to make a request with your favourite HTTP
+client as before.
+
+#+begin_src clojure
+  (def req
+    {:request-method :get
+     :url "https://api.twitter.com/account/verify_credentials"})
+
+  (-> consumer
+      (one/sign-request req)
+      http/request)
+#+end_src

--- a/project.clj
+++ b/project.clj
@@ -6,5 +6,5 @@
   :dependencies [[crypto-random "1.2.0"]
                  [org.clojure/clojure "1.8.0"]
                  [pandect "0.5.4"]
-                 [prismatic/schema "1.0.5"]
+                 [prismatic/schema "1.1.0"]
                  [ring/ring-codec "1.0.0"]])


### PR DESCRIPTION
This makes it easier to send signed requests yourself, without having to worry about creating nonces, and/or timestamps.
