### PR TITLE
Make parse-auth-header public

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,21 @@
 #+TITLE: Changes
+#+STARTUP: content
 
 * 0.2.0
+** Add ~parse-auth-header~ utility function
+Add ~parse-auth-header~ function that was previously only used in the test
+suite. This function is really handy in other test suites too!
+
+#+begin_src clojure
+  (require '[oauth.one :as one])
+
+  (one/parse-auth-header "OAuth oauth_consumer_key=\"key\"")
+  ;; => {"oauth_consumer_key" "key"}
+#+end_src
+
+The function works both with and without the ~OAuth~ prefix.
+
+** Improved signed request
 There are some fairly significant *breaking* changes in this release for anyone
 who made direct use of ~signed-request~ and its associated schema.
 

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,6 @@
                  [org.clojure/clojure "1.8.0"]
                  [pandect "0.5.4"]
                  [prismatic/schema "1.1.0"]
-                 [ring/ring-codec "1.0.0"]])
+                 [ring/ring-codec "1.0.0"]]
+  :profiles
+  {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}})

--- a/src/oauth/one.clj
+++ b/src/oauth/one.clj
@@ -130,6 +130,16 @@
 ;; -----------------------------------------------------------------------------
 ;; Request signing
 
+(s/defn parse-auth-header :- {s/Str s/Str}
+  "The inverse of `auth-headers->str`."
+  [s :- s/Str]
+  (reduce
+   #(if-let [[_ k v] (re-find #"(.*?)=\"(.*?)\"" %2)]
+      (assoc %1 k (codec/url-decode v))
+      %1)
+   {}
+   (str/split (str/replace s #"(?i)^oauth\s+" "") #",\s+")))
+
 (s/defn auth-headers->str :- s/Str
   "The OAuth Protocol Parameters are sent in the Authorization header the
   following way:


### PR DESCRIPTION
This is really handy if/when you want to test your own OAuth logic outside of the library.
