### PR TITLE
Generate an alphanumeric nonce

### DIFF
--- a/test/oauth/one_test.clj
+++ b/test/oauth/one_test.clj
@@ -58,6 +58,17 @@
     [(str scheme "://" host path) (codec/form-decode query)]))
 
 ;; -----------------------------------------------------------------------------
+;; Nonce
+
+(def ^:private gen-int-gt-zero
+  (gen/such-that #(< 0 %) gen/pos-int))
+
+(defspec t-nonce
+  1000
+  (prop/for-all [n gen-int-gt-zero]
+    (re-matches (re-pattern (format "(?i)[a-z0-9]{%s}" n)) (nonce n))))
+
+;; -----------------------------------------------------------------------------
 ;; Consumer
 
 (deftest t-make-consumer


### PR DESCRIPTION
I'm not sure why Twitter don't like some ASCII characters, but I've seen intermittent authentication issues, which I think are coming from non-word characters in the old nonces.

> The oauth_nonce parameter is a unique token your application should
>   generate for each unique request. Twitter will use this value to
>   determine whether a request has been submitted multiple times. The
>   value for this request was generated by base64 encoding 32 bytes of
>   random data, and stripping out all non-word characters, but any
>   approach which produces a relatively random alphanumeric string should
>   be OK here.

https://twittercommunity.com/t/how-to-generate-an-oauth-nonce/1307
