### PR TITLE
Fix encoding

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,12 @@
 #+TITLE: Changes
 #+STARTUP: content
 
+* 0.5.0
+Fix escaping of characters by sticking more closely to [[https://www.ietf.org/rfc/rfc3986.txt][RFC 3986]].
+
+This release also removes the dependency on crypto-random, as we now generate
+nonces more directly.
+
 * 0.4.0
 Avoid non-word characters in nonces.
 

--- a/test/oauth/one_test.clj
+++ b/test/oauth/one_test.clj
@@ -58,6 +58,14 @@
     [(str scheme "://" host path) (codec/form-decode query)]))
 
 ;; -----------------------------------------------------------------------------
+;; OAuth encode
+
+(defspec t-oauth-encode-roundtrip
+  1000
+  (prop/for-all [^String s gen/string-ascii]
+    (= (oauth-decode (oauth-encode s)))))
+
+;; -----------------------------------------------------------------------------
 ;; Nonce
 
 (def ^:private gen-int-gt-zero


### PR DESCRIPTION
Stick to RFC 3986 when encoding strings.
