### PR TITLE
Make signing a request easier

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,40 @@
 #+TITLE: Changes
 #+STARTUP: content
 
+* 0.6.0
+*No breaking changes.*
+
+You can now sign request more easily. Previously, you'd have to create OAuth
+headers yourself, and associate in the OAuth token from an access token. Then
+you'd need to pass in your access token secret for the signing process. The
+whole dance looked something like this:
+
+#+begin_src clojure
+  (one/sign-request (one/make-consumer config)
+                    {:oauth-headers (merge (one/make-oauth-headers consumer)
+                                           {"oauth_token" token})
+                     :request-method :get
+                     :url "https://www.example.com/api"}
+                    secret)
+#+end_src
+
+Based on feedback from @ilevd it was apparent this is a little clunky, and
+exposing the OAuth protocol wasn't very user friendly so I've extended
+~sign-request~ to support both the old version and this easier API:
+
+#+begin_src clojure
+  (one/sign-request (one/make-consumer config)
+                    {:request-method :get
+                     :url "https://www.example.com/api"}
+                    {:token "access-token"
+                     :secret "access-token-secret"})
+#+end_src
+
+Notice that you can pass an access token map as the third argument to
+~sign-request~, and internally we juggle things around to do the right thing.
+
+And, you can still pass in OAuth headers inside the request map if you so wish.
+
 * 0.5.0
 Fix escaping of characters by sticking more closely to [[https://www.ietf.org/rfc/rfc3986.txt][RFC 3986]].
 

--- a/README.org
+++ b/README.org
@@ -171,23 +171,14 @@ cryptographically signed like any other so there's a function provided to make
 this easier in your app.
 
 #+begin_src clojure
-  (one/sign-request
-   consumer
-   {:request-method :get
-    :url "https://api.twitter.com/account/verify_credentials.json"
-    :query-params {"include_email" "true"
-                   "skip_statuses" "true"}})
+  (let [request {:request-method :get
+                 :url "https://api.twitter.com/account/verify_credentials.json"
+                 :query-params {"include_email" "true"
+                                "skip_statuses" "true"}}
+        access-token {:token "access-token"
+                      :secret "access-token-secret"}]
+    (one/sign-request consumer request access-token))
 #+end_src
 
 You can use the hash-map returned to make a request with your favourite HTTP
 client as before.
-
-#+begin_src clojure
-  (def req
-    {:request-method :get
-     :url "https://api.twitter.com/account/verify_credentials.json"})
-
-  (-> consumer
-      (one/sign-request req)
-      http/request)
-#+end_src


### PR DESCRIPTION
Now you can pass the consumer, the unsigned request, and an optional access
token like so:

``` clj
(one/sign-request consumer
                  {:request-method :get
                   :url "https://example.com/oauth?params=true"
                   :form-params {"a" 1 "b" 2}
                   :query-params {"c" 3 "d" 4}}
                  {:token "access-token"
                   :secret "access-token-secret"})
```

Internally, we juggle everything around for you in order to build a signed
request. That means no more calling `one/make-oauth-headers` etc. yourself if
you don't need to get at what we put in the "Authorization" header.